### PR TITLE
ci: auto-assign securehst to new issues and PRs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,35 @@
+name: Auto Assign
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request_target:
+    types:
+      - opened
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  auto-assign:
+    runs-on: self-hosted
+    steps:
+      # Assign the securehst account to every newly-opened issue and pull request
+      # so they generate assignment notifications. First-party github-script, no
+      # third-party action — see ASSIGNEES below to change who gets assigned.
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const ASSIGNEES = ["securehst"];
+            const { owner, repo } = context.repo;
+            // PRs are issues in the REST API, so addAssignees covers both.
+            const number = context.payload.issue?.number ?? context.payload.pull_request?.number;
+            if (!number) return;
+            try {
+              await github.rest.issues.addAssignees({ owner, repo, issue_number: number, assignees: ASSIGNEES });
+            } catch (err) {
+              core.warning(`Could not assign [${ASSIGNEES.join(", ")}] to #${number}: ${err.message}`);
+            }


### PR DESCRIPTION
## What

Adds an **Auto Assign** workflow that assigns the **`securehst`** account to every newly-opened **issue** and **pull request** (including bot PRs), so they land in your assigned list and generate notifications.

## How

First-party **`actions/github-script`** (SHA-pinned, `v9.0.0`) — no third-party action. On `issues: opened` and `pull_request_target: opened` it calls `issues.addAssignees` (PRs are issues in the REST API, so one call covers both). A `workflow_dispatch` trigger is included for manual smoke-testing. Assignment failures are non-fatal (`core.warning`), so a transient API hiccup never fails the run.

`runs-on` matches this repo's existing workflows. To change who gets assigned, edit the `ASSIGNEES` array.

## Rollout

Part of a securehst-wide rollout standardizing issue/PR auto-assignment (piloted on `accelerated-instruction`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
